### PR TITLE
Assign `false` to `Value` instead of throwing a no_entry error.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2016 Raivo Laanemets, Matthew Carter
+Copyright (c) 2013-2017 Raivo Laanemets, Matthew Carter, Sando George
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ as scope entries.
 Literal lists work as expected with the elements having the interpretation as
 the expressions above.
 
+## Undefined variables
+The default behaviour when a variable that is not in the scope (template data dict) is encountered is to throw a `no_entry` error. This behaviour can be modified to set the variable value to `false` (default is `error`) by setting the `undefined` option to `false` when rendering templates. For example:
+
+    st_render_file(test, _{
+        title: 'Hello',
+        items: [
+            _{ title: 'Item 1', content: 'Abc 1' },
+            _{ title: 'Item 1', content: 'Abc 2' }
+        ]
+    }, Out, _{ undefined: false }).
+
+This is useful in situations where a developer may want to include a block in the template based on the existence of a variable. For example:
+
+    {% if page_header %}
+    <h2>{{page_header}}</h2>
+    {% end %}
+
 ## Built-in functions
 
 There are three single-argument functions to encode URI parts: `encode_path`,

--- a/prolog/st/st_expr.pl
+++ b/prolog/st/st_expr.pl
@@ -1,5 +1,5 @@
 :- module(st_expr, [
-    st_eval/3,         % + Expr, +Scope, -Result
+    st_eval/4,         % + Expr, +Scope, +Options, -Result
     st_set_function/3, % +Name, +Arity, :Goal
     st_set_global/2    % +Name, +Value
 ]).
@@ -49,87 +49,91 @@ st_set_global(Name, Value):-
 
 % Strings.
 
-st_eval(String, _, String):-
+st_eval(String, _, _, String):-
     string(String), !.
 
 % Numbers.
 
-st_eval(Number, _, Number):-
+st_eval(Number, _, _, Number):-
     number(Number), !.
 
 % Variables.
 
-st_eval(Name, Scope, Value):-
+st_eval(Name, Scope, Options, Value):-
     atom(Name), !,
     (   get_dict(Name, Scope, Value)
     ->  true
     ;   (   global(Name, Value)
         ->  true
-        ;   Value = false)).
+        ;   (option(undefined(Undefined), Options))
+        ->  must_be(oneof(['error', 'false']), Undefined),
+            (   Undefined == 'error'
+            ->  throw(error(no_entry(Name)))
+            ;   Value = false) )).
 
 % Boolean negation.
 
-st_eval(\+(Cond), Scope, Value):- !,
+st_eval(\+(Cond), Scope, _, Value):- !,
     st_eval_bool(Cond, Scope, Bool),
     bool_neg(Bool, Value).
 
 % Less-than.
 
-st_eval(Left < Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left < Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   LeftValue < RightValue
     ->  Value = 1
     ;   Value = 0).
 
 % Greater-than.
 
-st_eval(Left > Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left > Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   LeftValue > RightValue
     ->  Value = 1
     ;   Value = 0).
 
 % Equality.
 
-st_eval(Left = Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left = Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   test_equality(LeftValue, RightValue)
     ->  Value = 1
     ;   Value = 0).
 
 % Inequality.
 
-st_eval(Left \= Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left \= Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   test_equality(LeftValue, RightValue)
     ->  Value = 0
     ;   Value = 1).
 
 % Less-than-equal.
 
-st_eval(Left =< Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left =< Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   LeftValue =< RightValue
     ->  Value = 1
     ;   Value = 0).
 
 % Greater-than-equal.
 
-st_eval(Left >= Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left >= Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   LeftValue >= RightValue
     ->  Value = 1
     ;   Value = 0).
 
 % Logical and.
 
-st_eval(','(Left, Right), Scope, Value):- !,
+st_eval(','(Left, Right), Scope, _, Value):- !,
     st_eval_bool(Left, Scope, LeftValue),
     (   LeftValue = 0
     ->  Value = 0
@@ -140,7 +144,7 @@ st_eval(','(Left, Right), Scope, Value):- !,
 
 % Logical or.
 
-st_eval(';'(Left, Right), Scope, Value):- !,
+st_eval(';'(Left, Right), Scope, _, Value):- !,
     st_eval_bool(Left, Scope, LeftValue),
     (   LeftValue = 1
     ->  Value = 1
@@ -151,178 +155,178 @@ st_eval(';'(Left, Right), Scope, Value):- !,
 
 % Unary minus.
 
-st_eval(-(Expr), Scope, Value):- !,
-    st_eval(Expr, Scope, ExprValue),
+st_eval(-(Expr), Scope, _, Value):- !,
+    st_eval(Expr, Scope, _{}, ExprValue),
     Value is -ExprValue.
 
 % Unary plus.
 
-st_eval(+(Expr), Scope, Value):- !,
-    st_eval(Expr, Scope, ExprValue),
+st_eval(+(Expr), Scope, _, Value):- !,
+    st_eval(Expr, Scope, _{}, ExprValue),
     Value is ExprValue.
 
 % Scope get.
 
-st_eval(Term, Scope, Value):-
+st_eval(Term, Scope, _, Value):-
     Term =.. ['.', Base, Name], !,
-    st_eval(Base, Scope, Tmp),
+    st_eval(Base, Scope, _{}, Tmp),
     '.'(Tmp, Name, Value).
 
 % Addition. String concatenation.
 
-st_eval(Left + Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left + Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     (   number(LeftValue)
     ->  Value is LeftValue + RightValue
     ;   string_concat(LeftValue, RightValue, Value)).
 
 % Substraction.
 
-st_eval(Left - Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left - Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue - RightValue.
 
 % Multiplication.
 
-st_eval(Left * Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left * Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue * RightValue.
 
 % Division.
 
-st_eval(Left / Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left / Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue / RightValue.
 
 % Modulo.
 
-st_eval(Left mod Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left mod Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue mod RightValue.
 
 % Reminder.
 
-st_eval(Left rem Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left rem Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue rem RightValue.
 
 % Integer division.
 
-st_eval(Left // Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left // Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue // RightValue.
 
 % Integer division (variant 2).
 
-st_eval(Left div Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left div Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue div RightValue.
 
 % Absolute value.
 
-st_eval(abs(Expr), Scope, Abs):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(abs(Expr), Scope, _, Abs):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Abs is abs(Value).
 
 % Sign.
 
-st_eval(sign(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(sign(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Sign is sign(Value).
 
 % Max.
 
-st_eval(max(Left, Right), Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(max(Left, Right), Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is max(LeftValue, RightValue).
 
 % Min.
 
-st_eval(min(Left, Right), Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(min(Left, Right), Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is min(LeftValue, RightValue).
 
 % Random.
 
-st_eval(random(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(random(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Sign is random(Value).
 
 % Round.
 
-st_eval(round(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(round(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Sign is round(Value).
 
 % Truncate.
 
-st_eval(truncate(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(truncate(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Sign is truncate(Value).
 
 % Floor.
 
-st_eval(floor(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(floor(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _, Value),
     Sign is floor(Value).
 
 % Ceiling.
 
-st_eval(ceiling(Expr), Scope, Sign):- !,
-    st_eval(Expr, Scope, Value),
+st_eval(ceiling(Expr), Scope, _, Sign):- !,
+    st_eval(Expr, Scope, _{}, Value),
     Sign is ceiling(Value).
 
 % Power.
 
-st_eval(Left ** Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left ** Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue ** RightValue.
 
 % Power, alternative.
 
-st_eval(Left ^ Right, Scope, Value):- !,
-    st_eval(Left, Scope, LeftValue),
-    st_eval(Right, Scope, RightValue),
+st_eval(Left ^ Right, Scope, _, Value):- !,
+    st_eval(Left, Scope, _{}, LeftValue),
+    st_eval(Right, Scope, _{}, RightValue),
     Value is LeftValue ^ RightValue.
 
 % Conditional expressions.
 
-st_eval(if(Cond, True, False), Scope, Value):- !,
+st_eval(if(Cond, True, False), Scope, _, Value):- !,
     st_eval_bool(Cond, Scope, CondValue),
     (   CondValue = 0
-    ->  st_eval(False, Scope, Value)
-    ;   st_eval(True, Scope, Value)).
+    ->  st_eval(False, Scope, _{}, Value)
+    ;   st_eval(True, Scope, _{}, Value)).
 
 % "Literal" atom.
 
-st_eval(atom(Atom), _, Atom):-
+st_eval(atom(Atom), _, _, Atom):-
     atom(Atom), !.
 
 % List literal
 
-st_eval(List, Scope, Value):-
+st_eval(List, Scope, _, Value):-
     is_list(List), !,
     st_eval_list(List, Scope, Value).
 
 % Function calls.
 
-st_eval(Compound, Scope, Value):-
+st_eval(Compound, Scope, _, Value):-
     compound(Compound), !,
     function_call(Compound, Scope, Value).
 
 st_eval_bool(Expr, Scope, Bool):-
-    st_eval(Expr, Scope, Value),
+    st_eval(Expr, Scope, _{}, Value),
     (   (Value = 0 ; Value = false)
     ->  Bool = 0
     ;   Bool = 1).
@@ -333,7 +337,7 @@ bool_neg(0, 1).
 % Evaluates list of expressions.
 
 st_eval_list([Expr|Exprs], Scope, [Value|Values]):-
-    st_eval(Expr, Scope, Value),
+    st_eval(Expr, Scope, _{}, Value),
     st_eval_list(Exprs, Scope, Values).
 
 st_eval_list([], _, []).

--- a/prolog/st/st_expr.pl
+++ b/prolog/st/st_expr.pl
@@ -65,7 +65,7 @@ st_eval(Name, Scope, Value):-
     ->  true
     ;   (   global(Name, Value)
         ->  true
-        ;   throw(error(no_entry(Name))))).
+        ;   Value = false)).
 
 % Boolean negation.
 

--- a/tests/expr.pl
+++ b/tests/expr.pl
@@ -11,222 +11,231 @@ myfun(A, B, Out):-
 :- st_set_global(myglobal, 42).
 
 test(string):-
-    st_eval("string", _{}, "string").
+    st_eval("string", _{}, _{}, "string").
 
 test(number):-
-    st_eval(123, _{}, 123).
+    st_eval(123, _{}, _{}, 123).
 
 test(variable):-
-    st_eval(a, _{ a: 123 }, 123).
+    st_eval(a, _{ a: 123 }, _{}, 123).
+
+test(undefined_variable_error):-
+    Term =.. [st_eval, a, _{}, _{undefined: 'error'}, _],
+    catch(Term, E, true),
+    term_string(E, Error),
+    Error == "error(no_entry(a))".
+
+test(undefined_variable_false):-
+    st_eval(a, _{}, _{undefined: 'false'}, false).
 
 test(list_empty):-
-    st_eval([], _{}, []).
+    st_eval([], _{}, _{}, []).
 
 test(list_non_empty):-
-    st_eval([a], _{ a: 123 }, [123]).
+    st_eval([a], _{ a: 123 }, _{}, [123]).
 
 test(bool_neg_1):-
-    st_eval(\+ 1, _{}, 0).
+    st_eval(\+ 1, _{}, _{}, 0).
 
 test(bool_neg_2):-
-    st_eval(\+ 2, _{}, 0).
+    st_eval(\+ 2, _{}, _{}, 0).
 
 test(bool_neg_3):-
-    st_eval(\+ "a", _{}, 0).
+    st_eval(\+ "a", _{}, _{}, 0).
 
 test(bool_neg_4):-
-    st_eval(\+ 0, _{}, 1).
+    st_eval(\+ 0, _{}, _{}, 1).
 
 test(bool_and_1):-
-    st_eval((0, 0), _{}, 0).
+    st_eval((0, 0), _{}, _{}, 0).
 
 test(bool_and_2):-
-    st_eval((1, 0), _{}, 0).
+    st_eval((1, 0), _{}, _{}, 0).
 
 test(bool_and_3):-
-    st_eval((0, 1), _{}, 0).
+    st_eval((0, 1), _{}, _{}, 0).
 
 test(bool_and_4):-
-    st_eval((1, 1), _{}, 1).
+    st_eval((1, 1), _{}, _{}, 1).
 
 test(bool_or_1):-
-    st_eval((0; 0), _{}, 0).
+    st_eval((0; 0), _{}, _{}, 0).
 
 test(bool_or_2):-
-    st_eval((1; 0), _{}, 1).
+    st_eval((1; 0), _{}, _{}, 1).
 
 test(bool_or_3):-
-    st_eval((0; 1), _{}, 1).
+    st_eval((0; 1), _{}, _{}, 1).
 
 test(bool_or_4):-
-    st_eval((1; 1), _{}, 1).
+    st_eval((1; 1), _{}, _{}, 1).
 
 test(less_than_true):-
-    st_eval(1 < 2, _{}, 1).
+    st_eval(1 < 2, _{}, _{}, 1).
 
 test(less_than_false):-
-    st_eval(2 < 1, _{}, 0).
+    st_eval(2 < 1, _{}, _{}, 0).
 
 test(greater_than_true):-
-    st_eval(2 > 1, _{}, 1).
+    st_eval(2 > 1, _{}, _{}, 1).
 
 test(greater_than_false):-
-    st_eval(1 > 2, _{}, 0).
+    st_eval(1 > 2, _{}, _{}, 0).
 
 test(equality_1):-
-    st_eval(1 = 1, _{}, 1).
+    st_eval(1 = 1, _{}, _{}, 1).
 
 test(equality_2):-
-    st_eval(2 = 1, _{}, 0).
+    st_eval(2 = 1, _{}, _{}, 0).
 
 test(equality_3):-
-    st_eval(a = a, _{ a: 123 }, 1).
+    st_eval(a = a, _{ a: 123 }, _{}, 1).
 
 test(equality_4):-
-    st_eval(a = "abc", _{ a: abc }, 1).
+    st_eval(a = "abc", _{ a: abc }, _{}, 1).
 
 test(equality_5):-
-    st_eval("abc" = a, _{ a: abc }, 1).
+    st_eval("abc" = a, _{ a: abc }, _{}, 1).
 
 test(equality_6):-
-    st_eval("abc" = 1, _{}, 0).
+    st_eval("abc" = 1, _{}, _{}, 0).
 
 test(equality_7):-
-    st_eval(1 = "abc", _{}, 0).
+    st_eval(1 = "abc", _{}, _{}, 0).
 
 test(inequality_1):-
-    st_eval(1 \= 0, _{}, 1).
+    st_eval(1 \= 0, _{}, _{}, 1).
 
 test(inequality_2):-
-    st_eval(1 \= 1, _{}, 0).
+    st_eval(1 \= 1, _{}, _{}, 0).
 
 test(inequality_3):-
-    st_eval(atom(a) \= "b", _{}, 1).
+    st_eval(atom(a) \= "b", _{}, _{}, 1).
 
 test(inequality_4):-
-    st_eval(atom(a) \= "a", _{}, 0).
+    st_eval(atom(a) \= "a", _{}, _{}, 0).
 
 test(less_than_equal_true):-
-    st_eval(1 =< 2, _{}, 1).
+    st_eval(1 =< 2, _{}, _{}, 1).
 
 test(less_than_equal_false):-
-    st_eval(2 =< 1, _{}, 0).
+    st_eval(2 =< 1, _{}, _{}, 0).
 
 test(greater_than_equal_true):-
-    st_eval(2 >= 1, _{}, 1).
+    st_eval(2 >= 1, _{}, _{}, 1).
 
 test(greater_than_equal_false):-
-    st_eval(1 >= 2, _{}, 0).
+    st_eval(1 >= 2, _{}, _{}, 0).
 
 test(unary_minus):-
-    st_eval(-(1), _{}, -1).
+    st_eval(-(1), _{}, _{}, -1).
 
 test(unary_plus):-
-    st_eval(+(1), _{}, 1).
+    st_eval(+(1), _{}, _{}, 1).
 
 test(scope_get):-
     Term =.. ['.', a, b],
-    st_eval(Term, _{ a:_{ b: 123 } }, 123).
+    st_eval(Term, _{ a:_{ b: 123 } }, _{}, 123).
 
 test(scope_get_nested):-
     Inner =.. ['.', a, b],
     Term =.. ['.', Inner, c],
-    st_eval(Term, _{ a:_{ b: _{ c: 123 } } }, 123).
+    st_eval(Term, _{ a:_{ b: _{ c: 123 } } }, _{}, 123).
 
 test(dict_funcall):-
     Dict = point{x:1, y:2},
     Term =.. ['.', a, multiply(3)],
-    st_eval(Term, _{ a: Dict }, point{x:3,y:6}).
+    st_eval(Term, _{ a: Dict }, _{}, point{x:3,y:6}).
 
 test(addition):-
-    st_eval(2 + 1, _{}, 3).
+    st_eval(2 + 1, _{}, _{}, 3).
 
 test(concat_atom):-
-    st_eval(atom(abc) + 1, _{}, abc1).
+    st_eval(atom(abc) + 1, _{}, _{}, abc1).
 
 test(concat_string):-
-    st_eval("abc" + 1, _{}, "abc1").
+    st_eval("abc" + 1, _{}, _{}, "abc1").
 
 test(substraction):-
-    st_eval(3 - 1, _{}, 2).
+    st_eval(3 - 1, _{}, _{}, 2).
 
 test(multiplication):-
-    st_eval(3 * 2, _{}, 6).
+    st_eval(3 * 2, _{}, _{}, 6).
 
 test(division):-
-    st_eval(6 / 2, _{}, 3).
+    st_eval(6 / 2, _{}, _{}, 3).
 
 test(modulo):-
-    st_eval(6 mod 4, _{}, 2).
+    st_eval(6 mod 4, _{}, _{}, 2).
 
 test(reminder):-
-    st_eval(3 rem 2, _{}, 1).
+    st_eval(3 rem 2, _{}, _{}, 1).
 
 test(integer_division_1):-
-    st_eval(7 // 2, _{}, 3).
+    st_eval(7 // 2, _{}, _{}, 3).
 
 test(integer_division_2):-
-    st_eval(7 div 2, _{}, 3).
+    st_eval(7 div 2, _{}, _{}, 3).
 
 test(abs_1):-
-    st_eval(abs(-3), _{}, 3).
+    st_eval(abs(-3), _{}, _{}, 3).
 
 test(abs_2):-
-    st_eval(abs(3), _{}, 3).
+    st_eval(abs(3), _{}, _{}, 3).
 
 test(sign_1):-
-    st_eval(sign(-3), _{}, -1).
+    st_eval(sign(-3), _{}, _{}, -1).
 
 test(sign_2):-
-    st_eval(sign(3), _{}, 1).
+    st_eval(sign(3), _{}, _{}, 1).
 
 test(max):-
-    st_eval(max(2, 3), _{}, 3).
+    st_eval(max(2, 3), _{}, _{}, 3).
 
 test(min):-
-    st_eval(min(2, 3), _{}, 2).
+    st_eval(min(2, 3), _{}, _{}, 2).
 
 test(random):-
-    st_eval(random(10), _{}, I),
+    st_eval(random(10), _{}, _{}, I),
     number(I).
 
 test(round):-
-    st_eval(round(3.9), _{}, 4).
+    st_eval(round(3.9), _{}, _{}, 4).
 
 test(truncate):-
-    st_eval(truncate(3.9), _{}, 3).
+    st_eval(truncate(3.9), _{}, _{}, 3).
 
 test(floor):-
-    st_eval(floor(3.9), _{}, 3).
+    st_eval(floor(3.9), _{}, _{}, 3).
 
 test(ceiling):-
-    st_eval(ceiling(3.9), _{}, 4).
+    st_eval(ceiling(3.9), _{}, _{}, 4).
 
 test(power):-
-    st_eval(3 ** 2, _{}, 9).
+    st_eval(3 ** 2, _{}, _{}, 9).
 
 test(power):-
-    st_eval(3 ^ 2, _{}, 9).
+    st_eval(3 ^ 2, _{}, _{}, 9).
 
 test(function):-
-    st_eval(myfun(2, 3), _{}, 5).
+    st_eval(myfun(2, 3), _{}, _{}, 5).
 
 test(function_composition):-
-    st_eval(myfun(myfun(2, 3), 4), _{}, 9).
+    st_eval(myfun(myfun(2, 3), 4), _{}, _{}, 9).
 
 test(global):-
-    st_eval(myglobal, _{}, 42).
+    st_eval(myglobal, _{}, _{}, 42).
 
 test(global_shadow):-
-    st_eval(myglobal, _{ myglobal: 24 }, 24).
+    st_eval(myglobal, _{ myglobal: 24 }, _{}, 24).
 
 test(condition_true):-
-    st_eval(if(2, 3, 4), _{}, 3).
+    st_eval(if(2, 3, 4), _{}, _{}, 3).
 
 test(condition_false_1):-
-    st_eval(if(0, 3, 4), _{}, 4).
+    st_eval(if(0, 3, 4), _{}, _{}, 4).
 
 test(condition_false_2):-
-    st_eval(if(a, 3, 4), _{ a: false }, 4).
+    st_eval(if(a, 3, 4), _{ a: false }, _{}, 4).
 
 :- end_tests(st_expr).

--- a/tests/funs.pl
+++ b/tests/funs.pl
@@ -4,12 +4,12 @@
 :- use_module(prolog/st/st_funs).
 
 test(encode_path):-
-    st_eval(encode_path("/f oo/bar"), _{}, '/f%20oo/bar').
+    st_eval(encode_path("/f oo/bar"), _{}, _{}, '/f%20oo/bar').
 
 test(encode_query_value):-
-    st_eval(encode_query_value("foo&bar"), _{}, 'foo%26bar').
+    st_eval(encode_query_value("foo&bar"), _{}, _{}, 'foo%26bar').
 
 test(encode_fragment):-
-    st_eval(encode_fragment("foo#bar"), _{}, 'foo%23bar').
+    st_eval(encode_fragment("foo#bar"), _{}, _{}, 'foo%23bar').
 
 :- end_tests(st_funs).


### PR DESCRIPTION
This is useful in situations where the user may want to include a block in the template based on the existence of a variable. For example:

```html
{% if page_header %}
<h2>{{page_header}}</h2>
{% end %}
```