### PR TITLE
Added User-Defined Syntax Delimiters

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2013-2017 Raivo Laanemets, Matthew Carter, Sando George
+Copyright (c) 2013-2020 Raivo Laanemets, Matthew Carter, Sando George,
+James Lawrence Turner
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -81,6 +81,92 @@ output:
 
 It is not possible to mix two syntaxes through a single render call.
 
+## User-Defined Syntax
+
+Alternatively, you can specify your own templating delimiter syntax.
+This is useful to prevent template collision, in similar cases to semblance,
+but is more flexible.
+
+Input markup (`test.html` file):
+
+    <h1><%= title %></h1>
+    <% each items, item %>
+        <h2><%= item.title %></h2>
+        <div class="content"><%~ item.content %></div>
+    <% end %>
+
+rendering with data:
+
+    use_module(library(st/st_render)).
+
+    current_output(Out),
+    st_render_file(test, _{
+        title: 'Hello',
+        items: [
+            _{ title: 'Item 1', content: 'Abc 1' },
+            _{ title: 'Item 1', content: 'Abc 2' }
+        ]
+    }, Out, _{
+        frontend: syntax_tokens(
+            comment("<%#", "%>"),
+            out("<%=", "%>"),
+            out_unescaped("<%~", "%>"),
+            statement("<%", "%>")
+        )
+    }).
+
+output:
+
+    <h1>Hello</h1>
+
+    <h2>Item 1</h2>
+    <div class="content">Abc 1</div>
+
+    <h2>Item 1</h2>
+    <div class="content">Abc 2</div>
+
+## Unescape Keyword in User-Defined Syntax
+
+If you'd like to use an unescape keyword, you can use the helper
+`keyword_unescape_start(Token)` in place of a string, where `Token`
+is the starting Token to unify:
+
+    use_module(library(st/st_render)).
+
+    current_output(Out),
+    st_render_file(test, _{
+        title: 'Hello',
+        items: [
+            _{ title: 'Item 1', content: 'Abc 1' },
+            _{ title: 'Item 1', content: 'Abc 2' }
+        ]
+    }, Out, _{
+        frontend: syntax_tokens(
+            comment("<%#", "%>"),
+            out("<%=", "%>"),
+            out_unescaped(keyword_unescape_start("<%="), "%>"),
+            statement("<%", "%>")
+        )
+    }).
+
+With input markup (`test.html` file):
+
+    <h1><%= title %></h1>
+    <% each items, item %>
+        <h2><%= item.title %></h2>
+        <div class="content"><%= unescape item.content %></div>
+    <% end %>
+
+output:
+
+    <h1>Hello</h1>
+
+    <h2>Item 1</h2>
+    <div class="content">Abc 1</div>
+
+    <h2>Item 1</h2>
+    <div class="content">Abc 2</div>
+
 ## API
 
 Render template from string:
@@ -393,6 +479,7 @@ project [page](https://github.com/rla/simple-template).
 
 ## Changelog
 
+ * 2020-02-03 version 1.3.1. Add user-defined templating syntax.
  * 2017-11-03 version 1.2.0. Option to deal with undefined variables.
  * 2015-12-28 version 1.1.0. Add alternate syntax: semblance.
  * 2015-11-07 version 1.0.0. Removal of global options. Backwards-incompatible.

--- a/pack.pl
+++ b/pack.pl
@@ -1,7 +1,8 @@
 name(simple_template).
-version('1.3.0').
+version('1.3.1').
 title('Logic-free text (HTML) templates').
 author('Raivo Laanemets', 'http://rlaanemets.com/').
 author('Matthew Carter', 'http://ahungry.com/').
 author('Sando George', 'http://sandogeorge.github.io/').
+author('James Lawrence Turner', 'http://jlturner.com/').
 home('https://github.com/rla/simple-template').

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -4,6 +4,7 @@
     tests/funs,
     tests/tokens,
     tests/semblance_tokens,
+    tests/custom_tokens,
     tests/blocks,
     tests/render
 ], [ if(not_loaded) ]).

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -4,7 +4,7 @@
     tests/funs,
     tests/tokens,
     tests/semblance_tokens,
-    tests/custom_tokens,
+    tests/user_defined_tokens,
     tests/blocks,
     tests/render
 ], [ if(not_loaded) ]).

--- a/tests/user_defined_tokens.pl
+++ b/tests/user_defined_tokens.pl
@@ -1,0 +1,119 @@
+:- begin_tests(st_tokens_user_defined).
+
+:- use_module(prolog/st/st_tokens).
+
+% Syntax similar to embedded ruby / ERB
+erblike_frontend(
+    syntax_tokens(
+        comment("<%#", "%>"),
+        out("<%=", "%>"),
+        out_unescaped(keyword_unescape_start("<%="), "%>"),
+        statement("<%", "%>"))).
+
+test(text):-
+    erblike_frontend(Frontend),
+    st_tokens(`abc`,
+        _{ frontend: Frontend }, [text(`abc`)]).
+
+test(out):-
+    erblike_frontend(Frontend),
+    st_tokens(`<%= abc %>`,
+        _{ frontend: Frontend }, [out(abc)]).
+
+test(out_unescaped):-
+  erblike_frontend(Frontend),
+  st_tokens(`<%= unescape abc %>`,
+      _{ frontend: Frontend }, [out_unescaped(abc)]).
+
+test(out_unescaped_without_keyword):-
+  st_tokens(`<%~ abc %>`,
+      _{ frontend: syntax_tokens(
+          comment("<%#", "%>"),
+          out("<%=", "%>"),
+          out_unescaped("<%~", "%>"),
+          statement("<%", "%>"))
+      }, [out_unescaped(abc)]).
+
+test(end):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% end %>`,
+        _{ frontend: Frontend }, [end]).
+
+test(else):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% else %>`,
+        _{ frontend: Frontend }, [else]).
+
+test(include):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% include file/name %>`,
+        _{ frontend: Frontend }, [include(file/name)]).
+
+test(include_var):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% include file/name, var %>`,
+        _{ frontend: Frontend }, [include(file/name, var)]).
+
+test(dynamic_include):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% dynamic_include var %>`,
+        _{ frontend: Frontend }, [dynamic_include(var)]).
+
+test(block):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% block file/name %>`,
+        _{ frontend: Frontend }, [block(file/name)]).
+
+test(block_var):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% block file/name, var %>`,
+        _{ frontend: Frontend }, [block(file/name, var)]).
+
+test(slot):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% slot %>`,
+        _{ frontend: Frontend }, [slot]).
+
+test(if):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% if x=1 %>`,
+        _{ frontend: Frontend }, [if(x=1)]).
+
+test(else_if):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% else if x=2 %>`,
+        _{ frontend: Frontend }, [else_if(x=2)]).
+
+test(each_1):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% each items, item %>`,
+        _{ frontend: Frontend }, [each(items, item)]).
+
+test(each_2):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% each items, item, index %>`,
+        _{ frontend: Frontend }, [each(items, item, index)]).
+
+test(each_3):-
+    erblike_frontend(Frontend),
+    st_tokens(`<% each items, item, index, len %>`,
+        _{ frontend: Frontend }, [each(items, item, index, len)]).
+
+test(invalid):-
+    erblike_frontend(Frontend),
+    catch((st_tokens(`<% invalid`,
+        _{ frontend: Frontend }, _), fail),
+        error(invalid_instruction(_)), true).
+
+test(nonground):-
+    erblike_frontend(Frontend),
+    catch((st_tokens(`<%= A %>`,
+        _{ frontend: Frontend }, _), fail),
+        error(non_ground_expression(_)), true).
+
+test(comment):-
+    erblike_frontend(Frontend),
+    st_tokens(`<%# this is a comment #%>`,
+        _{ frontend: Frontend }, []).
+
+:- end_tests(st_tokens_user_defined).


### PR DESCRIPTION
End-users can define the syntax tokens used as the frontend for templating.
This allows end-users to prevent template collision when using a template
to create a template for a different templating syntax. Example of ERB-like
templating syntax included in tests. Additionally reordered out / out-unescaped
DCG rules to favor syntaxes which include the "unescape" keyword but use the
same template start tag. Both existing syntaxes are succinctly defined in
the same manner as a user defined syntax.